### PR TITLE
Enhanced Find feature to accept multiple prefix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -122,24 +122,25 @@ Examples:
 ### Locating clients by name: `find`
 
 
-Finds Clients in Fitbook whose names contain any of the given keywords.
+Finds Clients in Fitbook whose details contain any of the given keywords.
 
 
-Format: `find KEYWORD [MORE KEYWORDS] [p/PHONE] [e/EMAIL] [a/ADDRESS] [w/WEIGHT] [g/GENDER]…​`
+Format: `find [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [w/WEIGHT] [g/GENDER] [cal/CALORIE] [t/TAG]
+[app/APPOINTMENT]…​`
 
+* Prefix must be included, or there will be an exception. Multiple prefixes are allowed per command.
 * The search is case-insensitive. e.g `hans` will match `Hans`
-* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only keyword for name is compulsory in the command. The inclusion of other information is optional.
-  e.g. `find Hans` and `find Hans p/91234567` will work but `find p/91234567` will not work.
-* Only full words will be matched e.g. `Han` will not match `Hans`
-* Clients matching at least one keyword will be returned (i.e. `OR` search).
-  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+* The order of the keywords matters. e.g. `Hans Bo` will not match `Bo Hans`
+* Details containing the keyword will also be matched, even if both do not match exactly.
+  e.g. `Han` will match `Hans`, `John` will match `John Li` and `John Tan`,
+  `19` will match `1900` and `0190`
 
 Examples:
-* `find John` returns `john` and `John Doe`
-* `find John p/91234567` returns `John Tan`
-* `find alex david` returns `Alex Yeoh`, `David Li`<br>
-  ![result for 'find alex david'](images/findAlexDavidResult.png)
+* `find n/Alex` returns every client with 'Alex' in their name.
+* `find p/91234567` returns every client with phone numbers that matches or contains '91234567'.
+* `find n/Alex p/91234567` returns every client with 'Alex' in their name OR with phone numbers that matches or contains
+'91234567'
+* `find alex david` will throw an exception, since there is a missing prefix in the command.
 
 ### Deleting a client : `delete`
 

--- a/src/main/java/seedu/fitbook/commons/core/Messages.java
+++ b/src/main/java/seedu/fitbook/commons/core/Messages.java
@@ -6,7 +6,7 @@ package seedu.fitbook.commons.core;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_NO_ARGS = "Word parameter cannot be empty. \n%1$s";
+    public static final String MESSAGE_NO_KEYWORD = "Keyword parameter cannot be empty. \n%1$s";
     public static final String MESSAGE_NO_PREFIX = "Prefix parameter cannot be empty. \n%1$s";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PREFIX = "Invalid prefix inputted! \n%1$s";

--- a/src/main/java/seedu/fitbook/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/fitbook/logic/commands/FindCommand.java
@@ -2,6 +2,7 @@ package seedu.fitbook.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.fitbook.commons.core.Messages;
@@ -26,16 +27,17 @@ public class FindCommand extends Command {
             + "Available Prefixes: n, p, e, a, t, w, g, cal, app\n"
             + "Example: " + COMMAND_WORD + " n/alex or " + COMMAND_WORD + " p/91234567";
 
-    private final Predicate<Client> predicate;
+    private List<Predicate<Client>> predicateList;
 
-    public FindCommand(Predicate<Client> predicate) {
-        this.predicate = predicate;
+    public FindCommand(List<Predicate<Client>> predicateList) {
+        this.predicateList = predicateList;
     }
 
     @Override
     public CommandResult execute(FitBookModel model) {
         requireNonNull(model);
-        model.updateFilteredClientList(predicate);
+        Predicate<Client> combinedPredicates = predicateList.stream().reduce(x -> false, Predicate::or);
+        model.updateFilteredClientList(combinedPredicates);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredClientList().size()));
     }
@@ -44,6 +46,6 @@ public class FindCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && predicateList.equals(((FindCommand) other).predicateList)); // state check
     }
 }

--- a/src/main/java/seedu/fitbook/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/fitbook/logic/parser/FindCommandParser.java
@@ -51,9 +51,6 @@ public class FindCommandParser implements Parser<FindCommand> {
         checkParseStringFormat(argMultimap, args);
 
         List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
-        for (String nameKeyword : nameKeywords) {
-            System.out.println(nameKeyword);
-        }
         List<String> phoneKeywords = argMultimap.getAllValues(PREFIX_PHONE);
         List<String> emailKeywords = argMultimap.getAllValues(PREFIX_EMAIL);
         List<String> addressKeywords = argMultimap.getAllValues(PREFIX_ADDRESS);

--- a/src/main/java/seedu/fitbook/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/fitbook/logic/parser/FindCommandParser.java
@@ -2,13 +2,26 @@ package seedu.fitbook.logic.parser;
 
 import static seedu.fitbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.fitbook.commons.core.Messages.MESSAGE_INVALID_PREFIX;
-import static seedu.fitbook.commons.core.Messages.MESSAGE_NO_ARGS;
+import static seedu.fitbook.commons.core.Messages.MESSAGE_NO_KEYWORD;
 import static seedu.fitbook.commons.core.Messages.MESSAGE_NO_PREFIX;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_CALORIE;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_GENDER;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.fitbook.logic.parser.CliSyntax.PREFIX_WEIGHT;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import seedu.fitbook.logic.commands.FindCommand;
 import seedu.fitbook.logic.parser.exceptions.ParseException;
+import seedu.fitbook.model.client.Client;
 import seedu.fitbook.model.client.predicate.AddressContainsKeywordsPredicate;
 import seedu.fitbook.model.client.predicate.AppointmentContainsKeywordsPredicate;
 import seedu.fitbook.model.client.predicate.CalorieContainsKeywordsPredicate;
@@ -30,62 +43,93 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
 
-        checkParseStringFormat(trimmedArgs);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_APPOINTMENT, PREFIX_WEIGHT, PREFIX_GENDER, PREFIX_CALORIE, PREFIX_TAG);
 
-        String prefix = trimmedArgs.substring(0, trimmedArgs.indexOf('/'));
-        String[] allKeywords = {trimmedArgs.substring(trimmedArgs.indexOf('/') + 1)};
-        if (prefix.length() == 1) {
-            char prefixChar = prefix.charAt(0);
-            switch (prefixChar) {
-            case 'n':
-                return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            case 'p':
-                return new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            case 'e':
-                return new FindCommand(new EmailContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            case 'a':
-                return new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            case 't':
-                return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            case 'w':
-                return new FindCommand(new WeightContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            case 'g':
-                return new FindCommand(new GenderContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            default:
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_PREFIX, FindCommand.PREFIX_USAGE));
-            }
-        } else if (prefix.length() > 1) {
-            if (prefix.equals("cal")) {
-                return new FindCommand(new CalorieContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            } else if (prefix.equals("app")) {
-                return new FindCommand(new AppointmentContainsKeywordsPredicate(Arrays.asList(allKeywords)));
-            }
+        checkParseStringFormat(argMultimap, args);
+
+        List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+        for (String nameKeyword : nameKeywords) {
+            System.out.println(nameKeyword);
         }
-        throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        List<String> phoneKeywords = argMultimap.getAllValues(PREFIX_PHONE);
+        List<String> emailKeywords = argMultimap.getAllValues(PREFIX_EMAIL);
+        List<String> addressKeywords = argMultimap.getAllValues(PREFIX_ADDRESS);
+        List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
+        List<String> weightKeywords = argMultimap.getAllValues(PREFIX_WEIGHT);
+        List<String> genderKeywords = argMultimap.getAllValues(PREFIX_GENDER);
+        List<String> calorieKeywords = argMultimap.getAllValues(PREFIX_CALORIE);
+        List<String> appointmentKeywords = argMultimap.getAllValues(PREFIX_APPOINTMENT);
+
+        List<Predicate<Client>> predicates = new ArrayList<>();
+        if (!nameKeywords.isEmpty()) {
+            predicates.add(new NameContainsKeywordsPredicate(nameKeywords));
+        }
+        if (!phoneKeywords.isEmpty()) {
+            predicates.add(new PhoneContainsKeywordsPredicate(phoneKeywords));
+        }
+        if (!emailKeywords.isEmpty()) {
+            predicates.add(new EmailContainsKeywordsPredicate(emailKeywords));
+        }
+        if (!addressKeywords.isEmpty()) {
+            predicates.add(new AddressContainsKeywordsPredicate(addressKeywords));
+        }
+        if (!tagKeywords.isEmpty()) {
+            predicates.add(new TagContainsKeywordsPredicate(tagKeywords));
+        }
+        if (!weightKeywords.isEmpty()) {
+            predicates.add(new WeightContainsKeywordsPredicate(weightKeywords));
+        }
+        if (!genderKeywords.isEmpty()) {
+            predicates.add(new GenderContainsKeywordsPredicate(genderKeywords));
+        }
+        if (!calorieKeywords.isEmpty()) {
+            predicates.add(new CalorieContainsKeywordsPredicate(calorieKeywords));
+        }
+        if (!appointmentKeywords.isEmpty()) {
+            predicates.add(new AppointmentContainsKeywordsPredicate(appointmentKeywords));
+        }
+        return new FindCommand(predicates);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean areAvailablePrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
     /**
      * Checks the format of the given {@code String} of arguments in the context of the FindCommand.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public void checkParseStringFormat(String trimmedString) throws ParseException {
-        if (trimmedString.isEmpty()) {
+    public void checkParseStringFormat(ArgumentMultimap argMultimap, String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (args.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_NO_ARGS, FindCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        if (!trimmedString.contains("/")) {
+        if (trimmedArgs.substring(trimmedArgs.indexOf('/') + 1).isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_NO_PREFIX, FindCommand.PREFIX_USAGE));
+                    String.format(MESSAGE_NO_KEYWORD, FindCommand.MESSAGE_USAGE));
         }
 
-        if (trimmedString.substring(trimmedString.indexOf('/') + 1).isEmpty()) {
+        if (!trimmedArgs.contains("/")) {
             throw new ParseException(
-                    String.format(MESSAGE_NO_ARGS, FindCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_NO_PREFIX, FindCommand.MESSAGE_USAGE));
+        }
+
+        if (!areAvailablePrefixes(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_WEIGHT,
+                PREFIX_GENDER, PREFIX_EMAIL, PREFIX_TAG, PREFIX_APPOINTMENT, PREFIX_CALORIE)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_PREFIX, FindCommand.PREFIX_USAGE));
+        }
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/test/java/seedu/fitbook/logic/commands/client/FindCommandTest.java
+++ b/src/test/java/seedu/fitbook/logic/commands/client/FindCommandTest.java
@@ -11,8 +11,11 @@ import static seedu.fitbook.testutil.client.TypicalClients.FIONA;
 import static seedu.fitbook.testutil.client.TypicalClients.getTypicalFitBook;
 import static seedu.fitbook.testutil.routine.TypicalRoutines.getTypicalFitBookExerciseRoutine;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,6 +23,7 @@ import seedu.fitbook.logic.commands.FindCommand;
 import seedu.fitbook.model.FitBookModel;
 import seedu.fitbook.model.FitBookModelManager;
 import seedu.fitbook.model.UserPrefs;
+import seedu.fitbook.model.client.Client;
 import seedu.fitbook.model.client.predicate.NameContainsKeywordsPredicate;
 
 /**
@@ -33,19 +37,21 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        List<String> firstPredicate = Arrays.asList("first");
+        List<Predicate<Client>> firstPredicates = new ArrayList<>();
+        firstPredicates.add(new NameContainsKeywordsPredicate(firstPredicate));
+        FindCommand findFirstCommand = new FindCommand(firstPredicates);
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        List<String> secondPredicate = Arrays.asList("second");
+        List<Predicate<Client>> secondPredicates = new ArrayList<>();
+        secondPredicates.add(new NameContainsKeywordsPredicate(secondPredicate));
+        FindCommand findSecondCommand = new FindCommand(secondPredicates);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicates);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -61,8 +67,10 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noClientFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        List<Predicate<Client>> predicates = new ArrayList<>();
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+        predicates.add(predicate);
+        FindCommand command = new FindCommand(predicates);
         expectedFitBookModel.updateFilteredClientList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedFitBookModel);
         assertEquals(Collections.emptyList(), model.getFilteredClientList());
@@ -71,8 +79,10 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multipleClientsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        List<Predicate<Client>> predicates = new ArrayList<>();
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
+        predicates.add(predicate);
+        FindCommand command = new FindCommand(predicates);
         expectedFitBookModel.updateFilteredClientList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedFitBookModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredClientList());

--- a/src/test/java/seedu/fitbook/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/fitbook/logic/parser/FindCommandParserTest.java
@@ -1,16 +1,20 @@
 package seedu.fitbook.logic.parser;
 
+import static seedu.fitbook.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.fitbook.commons.core.Messages.MESSAGE_INVALID_PREFIX;
-import static seedu.fitbook.commons.core.Messages.MESSAGE_NO_ARGS;
 import static seedu.fitbook.commons.core.Messages.MESSAGE_NO_PREFIX;
 import static seedu.fitbook.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.fitbook.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.fitbook.logic.commands.FindCommand;
+import seedu.fitbook.model.client.Client;
 import seedu.fitbook.model.client.predicate.AddressContainsKeywordsPredicate;
 import seedu.fitbook.model.client.predicate.AppointmentContainsKeywordsPredicate;
 import seedu.fitbook.model.client.predicate.CalorieContainsKeywordsPredicate;
@@ -27,52 +31,78 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ",
-                String.format(MESSAGE_NO_ARGS, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "alex yeoh",
-                String.format(MESSAGE_NO_PREFIX, FindCommand.PREFIX_USAGE));
+                String.format(MESSAGE_NO_PREFIX, FindCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "b/911",
                 String.format(MESSAGE_INVALID_PREFIX, FindCommand.PREFIX_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
+
+        List<String> nameKeywords = Arrays.asList("Alice");
+        List<Predicate<Client>> namePredicate = new ArrayList<>();
+        namePredicate.add(new NameContainsKeywordsPredicate(nameKeywords));
         FindCommand expectedFindNameCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice Bob")));
-        assertParseSuccess(parser, "n/Alice Bob", expectedFindNameCommand);
+                new FindCommand(namePredicate);
+        assertParseSuccess(parser, " n/Alice", expectedFindNameCommand);
 
+        List<String> phoneKeywords = Arrays.asList("91234567");
+        List<Predicate<Client>> phonePredicates = new ArrayList<>();
+        phonePredicates.add(new PhoneContainsKeywordsPredicate(phoneKeywords));
         FindCommand expectedFindPhoneCommand =
-                new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList("91234567")));
-        assertParseSuccess(parser, "p/91234567", expectedFindPhoneCommand);
+                new FindCommand(phonePredicates);
+        assertParseSuccess(parser, " p/91234567", expectedFindPhoneCommand);
 
+        List<String> emailKeywords = Arrays.asList("aliceb@example.com");
+        List<Predicate<Client>> emailPredicates = new ArrayList<>();
+        emailPredicates.add(new EmailContainsKeywordsPredicate(emailKeywords));
         FindCommand expectedFindEmailCommand =
-                new FindCommand(new EmailContainsKeywordsPredicate(Arrays.asList("aliceb@example.com")));
-        assertParseSuccess(parser, "e/aliceb@example.com", expectedFindEmailCommand);
+                new FindCommand(emailPredicates);
+        assertParseSuccess(parser, " e/aliceb@example.com", expectedFindEmailCommand);
 
+        List<String> addressKeywords = Arrays.asList("30 Winchester Avenue");
+        List<Predicate<Client>> addressPredicates = new ArrayList<>();
+        addressPredicates.add(new AddressContainsKeywordsPredicate(addressKeywords));
         FindCommand expectedFindAddressCommand =
-                new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList("30 Winchester Avenue")));
-        assertParseSuccess(parser, "a/30 Winchester Avenue", expectedFindAddressCommand);
+                new FindCommand(addressPredicates);
+        assertParseSuccess(parser, " a/30 Winchester Avenue", expectedFindAddressCommand);
 
+        List<String> tagKeywords = Arrays.asList("friends");
+        List<Predicate<Client>> tagPredicates = new ArrayList<>();
+        tagPredicates.add(new TagContainsKeywordsPredicate(tagKeywords));
         FindCommand expectedFindTagCommand =
-                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("friends")));
-        assertParseSuccess(parser, "t/friends", expectedFindTagCommand);
+                new FindCommand(tagPredicates);
+        assertParseSuccess(parser, " t/friends", expectedFindTagCommand);
 
+        List<String> weightKeywords = Arrays.asList("40");
+        List<Predicate<Client>> weightPredicates = new ArrayList<>();
+        weightPredicates.add(new WeightContainsKeywordsPredicate(weightKeywords));
         FindCommand expectedFindWeightCommand =
-                new FindCommand(new WeightContainsKeywordsPredicate(Arrays.asList("40")));
-        assertParseSuccess(parser, "w/40", expectedFindWeightCommand);
+                new FindCommand(weightPredicates);
+        assertParseSuccess(parser, " w/40", expectedFindWeightCommand);
 
+        List<String> genderKeywords = Arrays.asList("M");
+        List<Predicate<Client>> genderPredicates = new ArrayList<>();
+        genderPredicates.add(new GenderContainsKeywordsPredicate(genderKeywords));
         FindCommand expectedFindGenderCommand =
-                new FindCommand(new GenderContainsKeywordsPredicate(Arrays.asList("M")));
-        assertParseSuccess(parser, "g/M", expectedFindGenderCommand);
+                new FindCommand(genderPredicates);
+        assertParseSuccess(parser, " g/M", expectedFindGenderCommand);
 
+        List<String> calorieKeywords = Arrays.asList("1000");
+        List<Predicate<Client>> caloriePredicates = new ArrayList<>();
+        caloriePredicates.add(new CalorieContainsKeywordsPredicate(calorieKeywords));
         FindCommand expectedFindCalorieCommand =
-                new FindCommand(new CalorieContainsKeywordsPredicate(Arrays.asList("1000")));
-        assertParseSuccess(parser, "cal/1000", expectedFindCalorieCommand);
+                new FindCommand(caloriePredicates);
+        assertParseSuccess(parser, " cal/1000", expectedFindCalorieCommand);
 
+        List<String> appointmentKeywords = Arrays.asList("12-12-2020");
+        List<Predicate<Client>> appointmentPredicates = new ArrayList<>();
+        appointmentPredicates.add(new AppointmentContainsKeywordsPredicate(appointmentKeywords));
         FindCommand expectedFindAppointmentCommand =
-                new FindCommand(new AppointmentContainsKeywordsPredicate(Arrays.asList("12-12-2019")));
-        assertParseSuccess(parser, "app/12-12-2019", expectedFindAppointmentCommand);
+                new FindCommand(appointmentPredicates);
+        assertParseSuccess(parser, " app/12-12-2020", expectedFindAppointmentCommand);
     }
-
 }

--- a/src/test/java/seedu/fitbook/logic/parser/FitBookParserTest.java
+++ b/src/test/java/seedu/fitbook/logic/parser/FitBookParserTest.java
@@ -8,8 +8,10 @@ import static seedu.fitbook.testutil.Assert.assertThrows;
 import static seedu.fitbook.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.fitbook.testutil.TypicalIndexes.INDEX_FIRST_ROUTINE;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,7 @@ import seedu.fitbook.logic.commands.ListClientsCommand;
 import seedu.fitbook.logic.parser.exceptions.ParseException;
 import seedu.fitbook.model.client.Client;
 import seedu.fitbook.model.client.predicate.NameContainsKeywordsPredicate;
+import seedu.fitbook.model.client.predicate.PhoneContainsKeywordsPredicate;
 import seedu.fitbook.model.routines.Routine;
 import seedu.fitbook.testutil.client.ClientBuilder;
 import seedu.fitbook.testutil.client.ClientUtil;
@@ -78,10 +81,15 @@ public class FitBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo bar");
+        List<String> nameKeywords = Arrays.asList("alex");
+        List<String> phoneKeywords = Arrays.asList("123");
+        List<Predicate<Client>> predicates = new ArrayList<>();
+        predicates.add(new NameContainsKeywordsPredicate(nameKeywords));
+        predicates.add(new PhoneContainsKeywordsPredicate(phoneKeywords));
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " n/" + nameKeywords.stream().collect(Collectors.joining(" "))
+                        + " p/" + phoneKeywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(predicates), command);
     }
 
     @Test


### PR DESCRIPTION
Limitations:

`find n/alex x/something` will show empty list due to x being an unknown prefix.
It should instead throw an error due to unknown format of the command.