### PR TITLE
Enable assertion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveFileName = 'fitbook.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Currently FitBook does not have assertions enabled in the build.gradle file.

Assertions are good to maintain defensiveness in our code.

Lets enable assertions in our build.gradle file.