### PR TITLE
Add defensive checks to export functions

### DIFF
--- a/RoutineFitBook.csv
+++ b/RoutineFitBook.csv
@@ -1,4 +1,4 @@
 Routine, Exercises
-Cardio2----3x10 Jumping Jacks----swimming
-Cardio3----running----swimming----cardio4----lik
-Cardio5----polling
+Jumps,3x10 Jumping Jacks----4x5 1km Run----
+Strength,3x10 Dumbbell Curls----4x5 Bench Press----
+Legs Exercises,3x10 Squats----4x5 Deadlift----5x10 10kg forward lunges----

--- a/RoutineFitBook.csv
+++ b/RoutineFitBook.csv
@@ -1,4 +1,4 @@
 Routine, Exercises
-Jumps,3x10 Jumping Jacks----4x5 1km Run----
-Strength,3x10 Dumbbell Curls----4x5 Bench Press----
-Legs Exercises,3x10 Squats----4x5 Deadlift----5x10 10kg forward lunges----
+Cardio2----3x10 Jumping Jacks----swimming
+Cardio3----running----swimming----cardio4----lik
+Cardio5----polling

--- a/src/main/java/seedu/fitbook/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/fitbook/logic/commands/ExportCommand.java
@@ -38,15 +38,13 @@ public class ExportCommand extends Command {
      */
     public static String writeToCsvFile(FitBookModel model) throws CommandException {
         List<Client> clients = model.getFilteredClientList().stream().collect(Collectors.toList());
-        try {
-            File csv = new File(FILE_NAME_CLIENT + CSV_EXTENSION);
-            PrintWriter pw = new PrintWriter(csv);
+        try (PrintWriter pw = new PrintWriter(new File(FILE_NAME_CLIENT + CSV_EXTENSION))) {
             writeHeaderRow(pw);
             writeClientRows(pw, clients);
+            return ExportCommand.MESSAGE_SUCCESS;
         } catch (FileNotFoundException e) {
             throw new CommandException(MESSAGE_FAILURE);
         }
-        return ExportCommand.MESSAGE_SUCCESS;
     }
 
     /**
@@ -64,9 +62,16 @@ public class ExportCommand extends Command {
      */
     public static void writeClientRows(PrintWriter pw, List<Client> clients) {
         for (Client client : clients) {
-            pw.printf("%s, %s, %s, %s, %s, %s\n", client.getName(), client.getPhone(), client.getEmail(),
-                    client.getAddress().toString().replaceAll("[^a-zA-Z0-9]", " "),
-                    client.getWeight(), client.getGender());
+            // defensive check to ensure client details are not null in any cases
+            String name = client.getName() != null ? String.valueOf(client.getName()) : "";
+            String phone = client.getPhone() != null ? String.valueOf(client.getPhone()) : "";
+            String email = client.getEmail() != null ? String.valueOf(client.getEmail()) : "";
+            String address = client.getAddress() != null
+                    ? client.getAddress().toString().replaceAll("[^a-zA-Z0-9]", " ") : "";
+            String weight = client.getWeight() != null ? String.valueOf(client.getWeight()) : "";
+            String gender = client.getGender() != null ? String.valueOf(client.getGender()) : "";
+
+            pw.printf("%s, %s, %s, %s, %s, %s\n", name, phone, email, address, weight, gender);
         }
         pw.close();
     }

--- a/src/main/java/seedu/fitbook/logic/commands/ExportRoutineCommand.java
+++ b/src/main/java/seedu/fitbook/logic/commands/ExportRoutineCommand.java
@@ -23,7 +23,7 @@ import seedu.fitbook.model.routines.Routine;
  */
 public class ExportRoutineCommand extends Command {
 
-    public static final String COMMAND_WORD = "exportRoutine";
+    public static final String COMMAND_WORD = "exportRoutines";
     public static final String MESSAGE_SUCCESS = "RoutineFile has been exported.";
     public static final String MESSAGE_FAILURE = "File could not be exported. Ensure the csv file is not opened in the "
             + "background ";
@@ -42,15 +42,14 @@ public class ExportRoutineCommand extends Command {
      */
     public static String writeToCsvFile(FitBookModel model) throws CommandException {
         List<Routine> routines = model.getFilteredRoutineList().stream().collect(Collectors.toList());
-        try {
-            File csv = new File(FILE_NAME_ROUTINE + CSV_EXTENSION);
-            PrintWriter pw = new PrintWriter(csv);
+        try (PrintWriter pw = new PrintWriter(new File(FILE_NAME_ROUTINE + CSV_EXTENSION))) {
             writeHeaderRow(pw);
             writeRoutineRows(pw, routines);
+            pw.close();
+            return ExportRoutineCommand.MESSAGE_SUCCESS;
         } catch (FileNotFoundException e) {
             throw new CommandException(MESSAGE_FAILURE);
         }
-        return ExportRoutineCommand.MESSAGE_SUCCESS;
     }
 
     /**
@@ -67,16 +66,17 @@ public class ExportRoutineCommand extends Command {
      * @param routines List of routines stored in FitBook.
      */
     public static void writeRoutineRows(PrintWriter pw, List<Routine> routines) {
-        StringBuilder s = new StringBuilder("");
+        StringBuilder s = new StringBuilder();
         for (Routine routine : routines) {
-            s.append(routine.getRoutineName().toString() + COMMA_SEPARATOR);
+            s.append(routine.getRoutineName().toString()).append(COMMA_SEPARATOR);
             for (Exercise exercise : routine.getExercises()) {
-                s.append(exercise.exerciseName + WHITE_SPACE);
+                if (exercise.exerciseName != null) {
+                    s.append(exercise.exerciseName).append(WHITE_SPACE);
+                }
             }
             s.append(NEW_LINE);
         }
         pw.print(s);
-        pw.close();
     }
 
 }

--- a/src/main/java/seedu/fitbook/model/routines/Exercise.java
+++ b/src/main/java/seedu/fitbook/model/routines/Exercise.java
@@ -52,4 +52,7 @@ public class Exercise {
         return exerciseName;
     }
 
+    public String getExerciseName() {
+        return exerciseName;
+    }
 }


### PR DESCRIPTION
This PR adds defensive checks to both export functions `export` and `exportRoutines`,  this defensive check will handle the event where client details are `null`, although with current implementation, the client details cannot be null. Adding this defensive check can handle cases where client details inevitably become `null` after we add future implementations.