### PR TITLE
Fix recommended calorie intake regex as it is not as advertised to be only 4 digit long

### DIFF
--- a/src/main/java/seedu/fitbook/model/client/Calorie.java
+++ b/src/main/java/seedu/fitbook/model/client/Calorie.java
@@ -11,7 +11,7 @@ public class Calorie {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Calories should only contain numbers, and it should be at least 4 digits long";
-    public static final String VALIDATION_REGEX = "\\d{4}";
+    public static final String VALIDATION_REGEX = "\\d{4,}";
     public final String value;
 
     /**


### PR DESCRIPTION
Current recommended calorie intake only allows 4 digits.

Required to fix it to be at least 4 digits long.

Let's fix the regex to allow more digits.

Only way to fix it is by allowing more limits for the digits.